### PR TITLE
fix: add padding to ellipsis button for larger tap target

### DIFF
--- a/Cider Remote/Views/MusicPlayer/PlayerControlsView.swift
+++ b/Cider Remote/Views/MusicPlayer/PlayerControlsView.swift
@@ -163,6 +163,7 @@ struct AdditionalControls: View {
         } label: {
             Image(systemName: "ellipsis")
                 .foregroundStyle(Color.white.opacity(0.6))
+                .padding(8)
                 .frame(width: buttonSize.dimension * (UIDevice.current.userInterfaceIdiom == .pad ? 1.1 : 1.0), height: buttonSize.dimension * (UIDevice.current.userInterfaceIdiom == .pad ? 1.1 : 1.0))
         }
         .buttonStyle(SpringyButtonStyle())


### PR DESCRIPTION
## Summary
- Added 8pt padding to the ellipsis button in player controls to increase the tappable area

## Problem
The ellipsis menu button in `AdditionalControls` had a hit box constrained to just the icon size, making it difficult to tap reliably on touch devices.

## Fix
Added `.padding(8)` before the `.frame()` modifier. This increases the tap target while keeping the visual appearance unchanged.

**Fixes #42**

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ciderapp/codesmith/Cider-Remote/pr/62"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785821048&installation_id=125908741&pr_number=62&repository=ciderapp%2FCider-Remote&return_to=https%3A%2F%2Fgithub.com%2Fciderapp%2FCider-Remote%2Fpull%2F62&signature=49bbc4c89ec8d6d386affdc7a624d0985e05001b375975f88a7a018a3bab2619"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->